### PR TITLE
Julia functionality and fixes for pymc3_turing_comparison

### DIFF
--- a/shops/pymc3_turing_comparison/turing_test.jl
+++ b/shops/pymc3_turing_comparison/turing_test.jl
@@ -8,8 +8,22 @@ addprocs(4)
 @everywhere using StatsFuns: logistic
 @everywhere using Turing
 
+"""
+    get_data(path, :y_label)
+
+Returns data for the logistic model split by X, y structure. 
+Retruns included breast cancer data by default.
+
+# Arguments:
+- `path::String="data/breast_cancer.csv"` path to csv file. 
+- `y_label::Symbol=:diagnosis` y label for target/dependent variable
+
+# Returns:
+- `X` Matrix containing X data/exogenous variables.
+- `y` Vector containing y label data/endogenous variables. 
+"""
 @everywhere function get_data(
-        path::String="data//breast_cancer.csv",
+        path::String="data/breast_cancer.csv",
         y_label::Symbol=:diagnosis
     )
     df = DataFrame(CSV.File(path))
@@ -19,6 +33,15 @@ addprocs(4)
     return X, y
 end
 
+"""
+    logistic_regression(x::Matrix{Float64}, y::Vector{Int64})
+
+Creates a logistic model to be used as an input argument in a sampler. 
+
+# Arguments:
+- `X::Matrix{Float64}`: Exogenous input data X in matrix format. 
+- `y::Vector{Int64}`: Endogenous/dependent variables vector.
+"""
 @everywhere @model function logistic_regression(
         X::Matrix{Float64},
         y::Vector{Int64}
@@ -36,6 +59,18 @@ end
     end
 end
 
+"""
+    profiler(X::Matrix{Float64}, y::Vector{Int64}, max_iters::Int64=10)
+
+# Arguments:
+- `X::Matrix{Float64}`: Exogenous variables
+- `y::Matrix{Int64}`: Endogenous variables 
+- `max_iters::Int64`: The specified number of iterations to execute the sampler for logistic regression.
+
+# Returns:
+- `times::Vector{Any}`: Execution times for each iteration.
+- `trace::Chains{Any}`: The trace generated in the final sample. 
+"""
 @everywhere function profiler(
         X::Matrix{Float64},
         y::Vector{Int64},
@@ -46,9 +81,9 @@ end
 
         time = @elapsed global trace = sample(
                 logistic_regression(X, y),
-                NUTS(2, 0.90),
+                NUTS(1000, 0.90),
                 MCMCDistributed(),
-                2,
+                1000,
                 4
             )
         append!(times, time)
@@ -60,7 +95,7 @@ end
     X, y = get_data()
     times, traces = profiler(X, y)
     println(times)
-    return times, traces
+    return times, trace
 end
 
-times, traces = main()
+times, trace = main()

--- a/shops/pymc3_turing_comparison/turing_test.jl
+++ b/shops/pymc3_turing_comparison/turing_test.jl
@@ -18,11 +18,11 @@ addprocs(4)
 
 @everywhere function get_data(
         path::String="data//breast_cancer.csv",
-        y_label::String="diagnosis"
+        y_label::Symbol=:diagnosis
     )
     df = DataFrame(CSV.File(path))
     y = df[!, y_label]
-    X = convert(Matrix, select!(df, Not(:y_label)))
+    X = convert(Matrix, select!(df, Not(y_label)))
     X = (X .- mean(X, dims=1)) ./ std(X, dims=1)
     return X, y
 


### PR DESCRIPTION
Hi Valerio,

I've implemented the canonical way to access the inner-scope `trace` on your sampler loop. There may be better ways to do this like overwriting a non-global variable one layer above, but for now I've left it as is.

There's also a fix to the way symbols were defined and accessed in the csv reader. 

I've added inline docstrings for all the functions other than `main(0` but you'll find that it doesn't take any advantage of Julia's documentation maker. It doesn't really matter for us because this is not a real package but I thought I'd mention it. The convention for docstrings (and other things) can be found at https://github.com/invenia/BlueStyle.

I'll get around to writing the times and traces outputs to a csv when I find time to work on this again, or you can do it yourself if you have time.

-mt 